### PR TITLE
Adds namespacing to deployed environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: |
             cd /root
             export NEW_IMAGE=7imbrook/life@sha256:$(cat deploy/meta/BUILD_SHA)
-            helm upgrade --install --set container.image=$NEW_IMAGE personal-page ./deploy/
+            helm upgrade --install --set container.image=$NEW_IMAGE timbrook-tech ./deploy/
   deploy-staging:
     docker:
       - image: 7imbrook/ci-deploy-tools
@@ -86,7 +86,11 @@ jobs:
           command: |
             cd /root
             export NEW_IMAGE=7imbrook/life@sha256:$(cat deploy/meta/BUILD_SHA)
-            helm upgrade --install --set ingress.host=staging.timbrook.tech --set container.image=$NEW_IMAGE personal-page-staging ./deploy/
+            helm upgrade --install --namespace staging \
+                                    --set ingress.host=staging.timbrook.tech \
+                                    --set container.image=$NEW_IMAGE \
+                                    --set environment.namespace=staging \
+                  timbrook-tech-staging ./deploy/
 workflows:
   version: 2
   deployment:

--- a/deploy/templates/Deployment.yaml
+++ b/deploy/templates/Deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{.Release.Name}}-app
+  namespace: {{.Values.environment.namespace}}
 spec:
   replicas: {{.Values.container.replicas}}
   selector:

--- a/deploy/templates/Ingress.yaml
+++ b/deploy/templates/Ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{.Release.Name}}-ingress
+  namespace: {{.Values.environment.namespace}}
   annotations:
     kubernetes.io/ingress.class: {{.Values.ingress.class}} 
 spec:

--- a/deploy/templates/Service.yaml
+++ b/deploy/templates/Service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{.Release.Name}}-service
+  namespace: {{.Values.environment.namespace}}
 spec:
   ports:
   - port: 80

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -1,4 +1,7 @@
 
+environment:
+  namespace: production
+
 ingress:
   class: traefik
   host: timbrook.tech


### PR DESCRIPTION
Let's not use the default for our two main environments. That way default can be used for experimentation more safely.